### PR TITLE
Fix: Use proper date-fns locale object

### DIFF
--- a/frontend/src/components/time/TimeEntries/TimeEntriesList.tsx
+++ b/frontend/src/components/time/TimeEntries/TimeEntriesList.tsx
@@ -32,6 +32,7 @@ import { useProjects } from '../../../contexts/ProjectsContext';
 import EditTimeEntryDialog from './EditTimeEntryDialog';
 import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
 
 interface TimeEntry {
   id: string;
@@ -322,7 +323,7 @@ const TimeEntriesList: React.FC<TimeEntriesListProps> = ({ projectId }) => {
                             }
                           </IconButton>
                           <Typography variant="subtitle1" sx={{ ml: 1 }}>
-                            {format(group.date, 'EEEE d MMMM yyyy', { locale: 'fr-FR' })}
+                            {format(group.date, 'EEEE d MMMM yyyy', { locale: fr })}
                           </Typography>
                         </Box>
                       </TableCell>


### PR DESCRIPTION
This PR fixes the locale error in TimeEntriesList by:
- Importing the proper fr locale object from date-fns/locale
- Using the locale object instead of locale string in format function

This resolves the 'locale must contain localize property' error.